### PR TITLE
Add more podcast appearances to interviews page

### DIFF
--- a/site/interviews.rst
+++ b/site/interviews.rst
@@ -5,13 +5,13 @@ I've given a few different interviews on podcasts and other formats over the yea
 This page keeps track of all of them,
 in case you want to hear my thoughts about things at certain points in time.
 
-* `Not So Boring Tech Writer - Building a home for documentarians with Eric Holscher <https://thenotboringtechwriter.com/episodes/building-a-home-for-documentarians-with-eric-holscher>`_
-* `Talk Python #448 - Full-Time Open Source Devs Panel <https://talkpython.fm/episodes/show/448/full-time-open-source-devs-panel>`_
-* `The Business of Open Source - Getting people to use the features you already have with Eric Holscher <https://www.emilyomier.com/podcast/getting-people-to-use-the-features-you-already-have-with-eric-holscher>`_
-* `The Rabbit Hole #116 - Documentation Hell and Documentation Heaven with Eric Holscher <https://www.radiofreerabbit.com/podcast/116-documentation-hell-and-documentation-heaven-with-eric-holscher>`_
-* `Sustain OSS - Read The Docs, Write The Docs, and EthicalAds <https://podcast.sustainoss.org/66>`_
-* `Talk Python #84 - Are we failing to fund Python's core infrastructure? <https://talkpython.fm/episodes/show/84/are-we-failing-to-fund-python-s-core-infrastructure>`_
-* `OReilly OSCON - Why you should document code - Eric Holscher & Marcia Riefer Johnston <https://www.youtube.com/watch?v=j6rQpO_6XUU>`_
-* `RFC #5: Eric Holscher – Documentation and the Value of Non-Code Contributions <https://changelog.com/rfc-5/>`_
-* `Not So Boring Tech Writer #5 -  Getting Involved in a Community <https://thenotboringtechwriter.com/episodes/skill-5-getting-involved-in-a-community>`_
-* `Podcast.__init__ #36 - Eric Holscher on Documentation <http://pythonpodcast.com/eric-holscher-documentation.html>`_
+* 2026-04 - `Not So Boring Tech Writer - Building a home for documentarians with Eric Holscher <https://thenotboringtechwriter.com/episodes/building-a-home-for-documentarians-with-eric-holscher>`_
+* 2024-10 - `The Business of Open Source - Getting people to use the features you already have with Eric Holscher <https://www.emilyomier.com/podcast/getting-people-to-use-the-features-you-already-have-with-eric-holscher>`_
+* 2024-02 - `Talk Python #448 - Full-Time Open Source Devs Panel <https://talkpython.fm/episodes/show/448/full-time-open-source-devs-panel>`_
+* 2021-02 - `Sustain OSS - Read The Docs, Write The Docs, and EthicalAds <https://podcast.sustainoss.org/66>`_
+* 2019-07 - `The Rabbit Hole #116 - Documentation Hell and Documentation Heaven with Eric Holscher <https://www.radiofreerabbit.com/podcast/116-documentation-hell-and-documentation-heaven-with-eric-holscher>`_
+* 2016-11 - `Talk Python #84 - Are we failing to fund Python's core infrastructure? <https://talkpython.fm/episodes/show/84/are-we-failing-to-fund-python-s-core-infrastructure>`_
+* 2016-08 - `RFC #5: Eric Holscher – Documentation and the Value of Non-Code Contributions <https://changelog.com/rfc-5/>`_
+* 2016-05 - `Not So Boring Tech Writer #5 -  Getting Involved in a Community <https://thenotboringtechwriter.com/episodes/skill-5-getting-involved-in-a-community>`_
+* 2015-12 - `Podcast.__init__ #36 - Eric Holscher on Documentation <http://pythonpodcast.com/eric-holscher-documentation.html>`_
+* 2015-07 - `OReilly OSCON - Why you should document code - Eric Holscher & Marcia Riefer Johnston <https://www.youtube.com/watch?v=j6rQpO_6XUU>`_

--- a/site/interviews.rst
+++ b/site/interviews.rst
@@ -5,8 +5,12 @@ I've given a few different interviews on podcasts and other formats over the yea
 This page keeps track of all of them,
 in case you want to hear my thoughts about things at certain points in time.
 
+* `Not So Boring Tech Writer - Building a home for documentarians with Eric Holscher <https://thenotboringtechwriter.com/episodes/building-a-home-for-documentarians-with-eric-holscher>`_
+* `Talk Python #448 - Full-Time Open Source Devs Panel <https://talkpython.fm/episodes/show/448/full-time-open-source-devs-panel>`_
 * `The Business of Open Source - Getting people to use the features you already have with Eric Holscher <https://www.emilyomier.com/podcast/getting-people-to-use-the-features-you-already-have-with-eric-holscher>`_
+* `The Rabbit Hole #116 - Documentation Hell and Documentation Heaven with Eric Holscher <https://www.radiofreerabbit.com/podcast/116-documentation-hell-and-documentation-heaven-with-eric-holscher>`_
 * `Sustain OSS - Read The Docs, Write The Docs, and EthicalAds <https://podcast.sustainoss.org/66>`_
+* `Talk Python #84 - Are we failing to fund Python's core infrastructure? <https://talkpython.fm/episodes/show/84/are-we-failing-to-fund-python-s-core-infrastructure>`_
 * `OReilly OSCON - Why you should document code - Eric Holscher & Marcia Riefer Johnston <https://www.youtube.com/watch?v=j6rQpO_6XUU>`_
 * `RFC #5: Eric Holscher – Documentation and the Value of Non-Code Contributions <https://changelog.com/rfc-5/>`_
 * `Not So Boring Tech Writer #5 -  Getting Involved in a Community <https://thenotboringtechwriter.com/episodes/skill-5-getting-involved-in-a-community>`_

--- a/site/interviews.rst
+++ b/site/interviews.rst
@@ -5,13 +5,13 @@ I've given a few different interviews on podcasts and other formats over the yea
 This page keeps track of all of them,
 in case you want to hear my thoughts about things at certain points in time.
 
-* 2026-04 - `Not So Boring Tech Writer - Building a home for documentarians with Eric Holscher <https://thenotboringtechwriter.com/episodes/building-a-home-for-documentarians-with-eric-holscher>`_
-* 2024-10 - `The Business of Open Source - Getting people to use the features you already have with Eric Holscher <https://www.emilyomier.com/podcast/getting-people-to-use-the-features-you-already-have-with-eric-holscher>`_
-* 2024-02 - `Talk Python #448 - Full-Time Open Source Devs Panel <https://talkpython.fm/episodes/show/448/full-time-open-source-devs-panel>`_
-* 2021-02 - `Sustain OSS - Read The Docs, Write The Docs, and EthicalAds <https://podcast.sustainoss.org/66>`_
-* 2019-07 - `The Rabbit Hole #116 - Documentation Hell and Documentation Heaven with Eric Holscher <https://www.radiofreerabbit.com/podcast/116-documentation-hell-and-documentation-heaven-with-eric-holscher>`_
-* 2016-11 - `Talk Python #84 - Are we failing to fund Python's core infrastructure? <https://talkpython.fm/episodes/show/84/are-we-failing-to-fund-python-s-core-infrastructure>`_
-* 2016-08 - `RFC #5: Eric Holscher – Documentation and the Value of Non-Code Contributions <https://changelog.com/rfc-5/>`_
-* 2016-05 - `Not So Boring Tech Writer #5 -  Getting Involved in a Community <https://thenotboringtechwriter.com/episodes/skill-5-getting-involved-in-a-community>`_
-* 2015-12 - `Podcast.__init__ #36 - Eric Holscher on Documentation <http://pythonpodcast.com/eric-holscher-documentation.html>`_
-* 2015-07 - `OReilly OSCON - Why you should document code - Eric Holscher & Marcia Riefer Johnston <https://www.youtube.com/watch?v=j6rQpO_6XUU>`_
+* April 2026 - `Not So Boring Tech Writer - Building a home for documentarians with Eric Holscher <https://thenotboringtechwriter.com/episodes/building-a-home-for-documentarians-with-eric-holscher>`_
+* October 2024 - `The Business of Open Source - Getting people to use the features you already have with Eric Holscher <https://www.emilyomier.com/podcast/getting-people-to-use-the-features-you-already-have-with-eric-holscher>`_
+* February 2024 - `Talk Python #448 - Full-Time Open Source Devs Panel <https://talkpython.fm/episodes/show/448/full-time-open-source-devs-panel>`_
+* February 2021 - `Sustain OSS - Read The Docs, Write The Docs, and EthicalAds <https://podcast.sustainoss.org/66>`_
+* July 2019 - `The Rabbit Hole #116 - Documentation Hell and Documentation Heaven with Eric Holscher <https://www.radiofreerabbit.com/podcast/116-documentation-hell-and-documentation-heaven-with-eric-holscher>`_
+* November 2016 - `Talk Python #84 - Are we failing to fund Python's core infrastructure? <https://talkpython.fm/episodes/show/84/are-we-failing-to-fund-python-s-core-infrastructure>`_
+* August 2016 - `RFC #5: Eric Holscher – Documentation and the Value of Non-Code Contributions <https://changelog.com/rfc-5/>`_
+* May 2016 - `Not So Boring Tech Writer #5 -  Getting Involved in a Community <https://thenotboringtechwriter.com/episodes/skill-5-getting-involved-in-a-community>`_
+* December 2015 - `Podcast.__init__ #36 - Eric Holscher on Documentation <http://pythonpodcast.com/eric-holscher-documentation.html>`_
+* July 2015 - `OReilly OSCON - Why you should document code - Eric Holscher & Marcia Riefer Johnston <https://www.youtube.com/watch?v=j6rQpO_6XUU>`_


### PR DESCRIPTION
## Summary
- Added four podcast appearances to `site/interviews.rst`:
  - Not So Boring Tech Writer — "Building a home for documentarians" (April 2026)
  - Talk Python #448 — Full-Time Open Source Devs Panel (Feb 2024)
  - The Rabbit Hole #116 — Documentation Hell and Documentation Heaven
  - Talk Python #84 — Are we failing to fund Python's core infrastructure? (Nov 2016)

## Test plan
- [ ] Build site locally and confirm links render on the Interviews page
